### PR TITLE
Add shared CI and reproducible issue-reporting safeguards

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,10 @@
 # Linux entrypoints and build metadata must not inherit Windows CRLF endings.
 *.sh text eol=lf
+*.c text eol=lf
+*.cc text eol=lf
+*.cpp text eol=lf
+*.h text eol=lf
+*.hpp text eol=lf
 Dockerfile text eol=lf
 *.cmake text eol=lf
 *.patch text eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,10 @@
+# Linux entrypoints and build metadata must not inherit Windows CRLF endings.
+*.sh text eol=lf
+Dockerfile text eol=lf
+*.cmake text eol=lf
+*.patch text eol=lf
+*.yaml text eol=lf
+*.yml text eol=lf
+*/rootfs/etc/cont-init.d/** text eol=lf
+*/rootfs/etc/s6-overlay/s6-rc.d/** text eol=lf
+*/rootfs/etc/s6-overlay/scripts/** text eol=lf

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -29,6 +29,36 @@ body:
 
 
   - type: textarea
+    id: environment
+    attributes:
+      label: "Environment"
+      description: |
+        Provide the versions, platform, radio, connection, and relevant add-on
+        settings. Exact values help distinguish host, firmware, and lifecycle
+        failures that otherwise produce similar logs.
+      placeholder: |
+        Add-on version:
+        Home Assistant Core:
+        Home Assistant Supervisor:
+        Home Assistant OS:
+        Host device and architecture:
+        Radio model/chipset:
+        Radio firmware and mode (RCP/NCP/Multi-PAN):
+        Connection (USB/UART/TCP) and device/network_device:
+        Backbone interface (configured or Supervisor-selected):
+        Host IPv6 forwarding enabled:
+        Baud rate:
+        Hardware flow control:
+        CPCd tracing:
+        OTBR enabled:
+        Firewall enabled:
+        NAT64 enabled:
+        Add-on restart recovers:
+        Full host reboot recovers:
+    validations:
+      required: true
+
+  - type: textarea
     id: problem_description
     attributes:
       label: "Problem Description"

--- a/.github/actions/check-addon-version/action.yaml
+++ b/.github/actions/check-addon-version/action.yaml
@@ -1,18 +1,16 @@
 name: Check HA Addon Version
+description: Check a Home Assistant add-on for a newer version
 inputs:
   addon_folder_name:
-    description: "Addon folder name"
+    description: "Add-on folder name, for example: matter_server"
     required: true
-    example: "matter_server"
   config:
-    description: "Addon config file name"
+    description: "Add-on config file name, for example: config.yaml"
     required: false
-    example: "config.yaml"
     default: "config.yaml"
   change_log:
-    description: "Change log file name"
+    description: "Changelog file name, for example: CHANGELOG.md"
     required: false
-    example: "CHANGELOG.md"
     default: "CHANGELOG.md"
 
 runs:

--- a/.github/actions/check-release/action.yaml
+++ b/.github/actions/check-release/action.yaml
@@ -1,13 +1,12 @@
 name: Check Release
+description: Check a GitHub repository for a newer release
 inputs:
   owner:
-    description: "Owner"
+    description: "Owner, for example: esphome"
     required: true
-    example: "esphome"
   repo:
-    description: "Repo"
+    description: "Repository, for example: home-assistant-addon"
     required: true
-    example: "home-assistant-addon"
 runs:
   using: "composite"
   steps:

--- a/.github/actions/compare-with-previous/action.yaml
+++ b/.github/actions/compare-with-previous/action.yaml
@@ -1,25 +1,21 @@
 name: Compare with previous release
+description: Compare release metadata with the previously recorded version
 inputs:
   owner:
-    description: "Owner"
+    description: "Owner, for example: esphome"
     required: true
-    example: "esphome"
   repo:
-    description: "Repo"
+    description: "Repository, for example: home-assistant-addon"
     required: true
-    example: "home-assistant-addon"
   current_version:
-    description: "Current Version"
+    description: "Current version, for example: 2023.10.0"
     required: true
-    example: "2023.10.0"
   release_url:
-    description: "Release URL"
+    description: "Release URL for the current version"
     required: true
-    example: "https://github.com/esphome/home-assistant-addon/releases/tag/2023.10.0"
   body:
-    description: "Release Body"
+    description: "Release body or changelog summary"
     required: true
-    example: "## Changelog\n\n- Fixes\n- New features"
 
 runs:
   using: "composite"

--- a/.github/workflows/lint-workflows.yml
+++ b/.github/workflows/lint-workflows.yml
@@ -1,0 +1,42 @@
+name: Lint GitHub Actions workflows
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+    paths:
+      - ".github/actions/**"
+      - ".github/workflows/**"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  actionlint:
+    name: Actionlint
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Lint workflow files
+        shell: bash
+        run: |
+          docker run --rm \
+            --cap-drop ALL \
+            --network none \
+            --read-only \
+            --pids-limit 128 \
+            --security-opt no-new-privileges \
+            --tmpfs /tmp:rw,nosuid,nodev,noexec,size=16m \
+            --volume "${GITHUB_WORKSPACE}:/repo:ro" \
+            --workdir /repo \
+            "docker.io/rhysd/actionlint:1.7.12@sha256:b1934ee5f1c509618f2508e6eb47ee0d3520686341fec936f3b79331f9315667" \
+            -color \
+            -pyflakes= \
+            -shellcheck=


### PR DESCRIPTION
## Summary

- lint every GitHub Actions workflow with commit-pinned Actionlint
- enforce LF for Linux runtime, build, workflow, patch, and C/C++ source inputs
- collect exact add-on, HAOS, architecture, radio, transport, backbone, forwarding, firewall, NAT64, restart, and reboot context in bug reports

This is the shared prerequisite for the two OTBR lifecycle review branches. It does not publish images or change add-on runtime behavior.

The C/C++ rule closes a Windows checkout discrepancy observed during exact-SHA validation: a committed LF build header had materialized as CRLF in an older worktree, forcing a different Docker build input.

## Local validation at 8d5215f036f91bd8339d14dc65b5b5110211cf7c

- Actionlint 1.7.12: pass
- issue-template YAML parse: pass
- line-ending attributes and non-vendored git diff checks: pass
